### PR TITLE
feat: 예상 요금 기능 추가

### DIFF
--- a/src/main/java/goorm/humandelivery/fare/application/EstimateFareService.java
+++ b/src/main/java/goorm/humandelivery/fare/application/EstimateFareService.java
@@ -1,0 +1,50 @@
+package goorm.humandelivery.fare.application;
+
+import goorm.humandelivery.driver.domain.TaxiType;
+import goorm.humandelivery.fare.application.port.in.EstimateFareUseCase;
+import goorm.humandelivery.fare.application.port.out.LoadTravelInfoPort;
+import goorm.humandelivery.fare.domain.FarePolicy;
+import goorm.humandelivery.fare.domain.NormalFarePolicy;
+import goorm.humandelivery.fare.domain.PremiumFarePolicy;
+import goorm.humandelivery.fare.domain.TravelInfo;
+import goorm.humandelivery.fare.dto.request.EstimateFareRequest;
+import goorm.humandelivery.fare.dto.response.EstimateFareResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.EnumMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EstimateFareService implements EstimateFareUseCase {
+
+    private final LoadTravelInfoPort loadTravelInfoPort;
+
+    @Override
+    public EstimateFareResponse estimateFare(EstimateFareRequest request) {
+        TravelInfo travelInfo = loadTravelInfoPort.loadTravelInfo(request.getExpectedOrigin(), request.getExpectedDestination());
+        double distance = travelInfo.getDistanceMeters();
+        Map<TaxiType, BigDecimal> result = new EnumMap<>(TaxiType.class);
+
+        for (TaxiType type : TaxiType.values()) {
+            FarePolicy policy = getPolicyByType(type);
+            BigDecimal fare = policy.estimateFare(distance, request.getRequestTime());
+            result.put(type, fare);
+            log.info("[EstimateFareService.estimateFare] 택시타입: {}, 요금: {}", type, fare);
+        }
+
+        return new EstimateFareResponse(result, travelInfo.getEstimatedFareByKakao());
+    }
+
+    private FarePolicy getPolicyByType(TaxiType type) {
+        return switch (type) {
+            case NORMAL -> new NormalFarePolicy();
+            case PREMIUM, VENTI -> new PremiumFarePolicy();
+        };
+    }
+}
+

--- a/src/main/java/goorm/humandelivery/fare/application/port/in/EstimateFareUseCase.java
+++ b/src/main/java/goorm/humandelivery/fare/application/port/in/EstimateFareUseCase.java
@@ -1,0 +1,10 @@
+package goorm.humandelivery.fare.application.port.in;
+
+import goorm.humandelivery.fare.dto.request.EstimateFareRequest;
+import goorm.humandelivery.fare.dto.response.EstimateFareResponse;
+
+public interface EstimateFareUseCase {
+
+    EstimateFareResponse estimateFare(EstimateFareRequest estimateFareRequest);
+
+}

--- a/src/main/java/goorm/humandelivery/fare/application/port/out/LoadTravelInfoPort.java
+++ b/src/main/java/goorm/humandelivery/fare/application/port/out/LoadTravelInfoPort.java
@@ -1,0 +1,8 @@
+package goorm.humandelivery.fare.application.port.out;
+
+import goorm.humandelivery.fare.domain.TravelInfo;
+import goorm.humandelivery.shared.location.domain.Location;
+
+public interface LoadTravelInfoPort {
+    TravelInfo loadTravelInfo(Location origin, Location destination);
+}

--- a/src/main/java/goorm/humandelivery/fare/domain/AbstractFarePolicy.java
+++ b/src/main/java/goorm/humandelivery/fare/domain/AbstractFarePolicy.java
@@ -1,0 +1,33 @@
+package goorm.humandelivery.fare.domain;
+
+import lombok.AllArgsConstructor;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalTime;
+import java.util.List;
+
+@AllArgsConstructor
+public abstract class AbstractFarePolicy implements FarePolicy {
+
+    private final List<FareCondition> fareConditions;
+    private final double baseDistance;
+    private final double unitDistance;
+
+    @Override
+    public BigDecimal estimateFare(double distance, LocalTime requestTime) {
+        FareCondition matched = fareConditions.stream()
+                .filter(c -> c.isMatch(requestTime))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("적용 가능한 요금이 없습니다."));
+
+        BigDecimal fare = matched.getBaseFare();
+        if (distance > baseDistance) {
+            double extra = distance - baseDistance;
+            BigDecimal unitCount = BigDecimal.valueOf(extra / unitDistance).setScale(0, RoundingMode.DOWN);
+            fare = fare.add(matched.getUnitFare().multiply(unitCount));
+        }
+
+        return fare.setScale(0, RoundingMode.HALF_UP);
+    }
+}

--- a/src/main/java/goorm/humandelivery/fare/domain/FareCondition.java
+++ b/src/main/java/goorm/humandelivery/fare/domain/FareCondition.java
@@ -1,0 +1,25 @@
+package goorm.humandelivery.fare.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+
+@Getter
+@AllArgsConstructor
+public class FareCondition {
+
+    private final LocalTime start;
+    private final LocalTime end;
+    private final BigDecimal baseFare;
+    private final BigDecimal unitFare;
+
+    public boolean isMatch(LocalTime time) {
+        return start.isBefore(end)
+                ? !time.isBefore(start) && time.isBefore(end)
+                : !time.isBefore(start) || time.isBefore(end);
+    }
+
+
+}

--- a/src/main/java/goorm/humandelivery/fare/domain/FarePolicy.java
+++ b/src/main/java/goorm/humandelivery/fare/domain/FarePolicy.java
@@ -1,0 +1,10 @@
+package goorm.humandelivery.fare.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+
+public interface FarePolicy {
+
+    BigDecimal estimateFare(double distance, LocalTime requestTime);
+
+}

--- a/src/main/java/goorm/humandelivery/fare/domain/NormalFarePolicy.java
+++ b/src/main/java/goorm/humandelivery/fare/domain/NormalFarePolicy.java
@@ -1,0 +1,15 @@
+package goorm.humandelivery.fare.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.List;
+
+public class NormalFarePolicy extends AbstractFarePolicy {
+    public NormalFarePolicy() {
+        super(List.of(
+                new FareCondition(LocalTime.of(23, 0), LocalTime.of(2, 0), BigDecimal.valueOf(6700), BigDecimal.valueOf(140)),
+                new FareCondition(LocalTime.of(22, 0), LocalTime.of(4, 0), BigDecimal.valueOf(5800), BigDecimal.valueOf(120)),
+                new FareCondition(LocalTime.of(4, 0), LocalTime.of(22, 0), BigDecimal.valueOf(4800), BigDecimal.valueOf(100))
+        ), 1600.0, 131.0);
+    }
+}

--- a/src/main/java/goorm/humandelivery/fare/domain/PremiumFarePolicy.java
+++ b/src/main/java/goorm/humandelivery/fare/domain/PremiumFarePolicy.java
@@ -1,0 +1,14 @@
+package goorm.humandelivery.fare.domain;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.List;
+
+public class PremiumFarePolicy extends AbstractFarePolicy {
+    public PremiumFarePolicy() {
+        super(List.of(
+                new FareCondition(LocalTime.of(22, 0), LocalTime.of(4, 0), BigDecimal.valueOf(8400), BigDecimal.valueOf(240)),
+                new FareCondition(LocalTime.of(4, 0), LocalTime.of(22, 0), BigDecimal.valueOf(7000), BigDecimal.valueOf(200))
+        ), 3000.0, 151.0);
+    }
+}

--- a/src/main/java/goorm/humandelivery/fare/domain/TravelInfo.java
+++ b/src/main/java/goorm/humandelivery/fare/domain/TravelInfo.java
@@ -1,0 +1,20 @@
+package goorm.humandelivery.fare.domain;
+
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+public class TravelInfo {
+
+    private final double distanceMeters;
+    private final int durationSeconds;
+    private final BigDecimal estimatedFareByKakao;
+
+    public TravelInfo(double distanceMeters, int durationSeconds, BigDecimal estimatedFareByKakao) {
+        this.distanceMeters = distanceMeters;
+        this.durationSeconds = durationSeconds;
+        this.estimatedFareByKakao = estimatedFareByKakao;
+    }
+
+}

--- a/src/main/java/goorm/humandelivery/fare/dto/request/EstimateFareRequest.java
+++ b/src/main/java/goorm/humandelivery/fare/dto/request/EstimateFareRequest.java
@@ -1,0 +1,19 @@
+package goorm.humandelivery.fare.dto.request;
+
+import goorm.humandelivery.shared.location.domain.Location;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EstimateFareRequest {
+
+    private Location expectedOrigin;
+    private Location expectedDestination;
+    private LocalTime requestTime;
+
+}

--- a/src/main/java/goorm/humandelivery/fare/dto/response/EstimateFareResponse.java
+++ b/src/main/java/goorm/humandelivery/fare/dto/response/EstimateFareResponse.java
@@ -1,0 +1,17 @@
+package goorm.humandelivery.fare.dto.response;
+
+import goorm.humandelivery.driver.domain.TaxiType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class EstimateFareResponse {
+
+    private Map<TaxiType, BigDecimal> estimatedFares;
+    private BigDecimal kakaoEstimatedFare;
+
+}

--- a/src/main/java/goorm/humandelivery/fare/infrastructure/kakao/KakaoTravelInfoAdapter.java
+++ b/src/main/java/goorm/humandelivery/fare/infrastructure/kakao/KakaoTravelInfoAdapter.java
@@ -1,0 +1,72 @@
+package goorm.humandelivery.fare.infrastructure.kakao;
+
+import goorm.humandelivery.fare.application.port.out.LoadTravelInfoPort;
+import goorm.humandelivery.fare.domain.TravelInfo;
+import goorm.humandelivery.fare.infrastructure.kakao.dto.KakaoDirectionResponse;
+import goorm.humandelivery.fare.infrastructure.kakao.dto.Route;
+import goorm.humandelivery.global.exception.InvalidRouteException;
+import goorm.humandelivery.shared.location.domain.Location;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.math.BigDecimal;
+import java.net.URI;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoTravelInfoAdapter implements LoadTravelInfoPort {
+
+    private static final String KAKAO_DIRECTION_URL = "https://apis-navi.kakaomobility.com/v1/directions";
+    private final RestTemplate restTemplate;
+
+    @Value("${kakao.rest.api.key}")
+    private String kakaoApiKey;
+
+    @Override
+    public TravelInfo loadTravelInfo(Location origin, Location destination) {
+        try {
+            URI uri = UriComponentsBuilder
+                    .fromUriString(KAKAO_DIRECTION_URL)
+                    .queryParam("origin", origin.getLongitude() + "," + origin.getLatitude())
+                    .queryParam("destination", destination.getLongitude() + "," + destination.getLatitude())
+                    .queryParam("priority", "RECOMMEND")
+                    .build()
+                    .toUri();
+
+            log.info("[KakaoTravelInfoAdapter.loadTravelInfo] request URI = {}", uri);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "KakaoAK " + kakaoApiKey);
+            HttpEntity<Object> entity = new HttpEntity<>(headers);
+
+            ResponseEntity<KakaoDirectionResponse> response = restTemplate.exchange(uri, HttpMethod.GET, entity, KakaoDirectionResponse.class);
+
+            Route route = response.getBody().getRoutes().get(0);
+            int resultCode = route.getResultCode();
+            if (resultCode != 0) {
+                log.error("[resultCode = {}, 경로 탐색 실패]", resultCode);
+                throw new InvalidRouteException(resultCode, "카카오 경로 탐색 실패 (msg: " + route.getResultMsg() + ")");
+            }
+
+            double distance = route.getSummary().getDistance();
+            int duration = route.getSummary().getDuration();
+            int fare = route.getSummary().getFare().getTaxi();
+            log.info("[resultCode = {}, 경로 탐색 성공] 예상거리={}, 예상소요시간={}, 예상카카오요금={}", resultCode, distance, duration, fare);
+            return new TravelInfo(distance, duration, BigDecimal.valueOf(fare));
+        } catch (RestClientException e) {
+            log.error("카카오 API 호출 중 예외 발생: {}", e.getMessage(), e);
+            throw new RestClientException("카카오 API 호출 실패", e);
+        }
+    }
+
+}

--- a/src/main/java/goorm/humandelivery/fare/infrastructure/kakao/dto/Fare.java
+++ b/src/main/java/goorm/humandelivery/fare/infrastructure/kakao/dto/Fare.java
@@ -1,0 +1,12 @@
+package goorm.humandelivery.fare.infrastructure.kakao.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Fare {
+
+    private int taxi;
+
+}

--- a/src/main/java/goorm/humandelivery/fare/infrastructure/kakao/dto/KakaoDirectionResponse.java
+++ b/src/main/java/goorm/humandelivery/fare/infrastructure/kakao/dto/KakaoDirectionResponse.java
@@ -1,0 +1,14 @@
+package goorm.humandelivery.fare.infrastructure.kakao.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class KakaoDirectionResponse {
+
+    private List<Route> routes;
+
+}

--- a/src/main/java/goorm/humandelivery/fare/infrastructure/kakao/dto/Route.java
+++ b/src/main/java/goorm/humandelivery/fare/infrastructure/kakao/dto/Route.java
@@ -1,0 +1,19 @@
+package goorm.humandelivery.fare.infrastructure.kakao.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Route {
+
+    @JsonProperty("result_code")
+    private int resultCode;
+
+    @JsonProperty("result_msg")
+    private String resultMsg;
+
+    private Summary summary;
+
+}

--- a/src/main/java/goorm/humandelivery/fare/infrastructure/kakao/dto/Summary.java
+++ b/src/main/java/goorm/humandelivery/fare/infrastructure/kakao/dto/Summary.java
@@ -1,0 +1,14 @@
+package goorm.humandelivery.fare.infrastructure.kakao.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class Summary {
+
+    private int distance;
+    private int duration;
+    private Fare fare;
+
+}

--- a/src/main/java/goorm/humandelivery/global/advice/StompExceptionAdvice.java
+++ b/src/main/java/goorm/humandelivery/global/advice/StompExceptionAdvice.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.client.RestClientException;
 
 @ControllerAdvice
 @Slf4j
@@ -105,5 +106,20 @@ public class StompExceptionAdvice {
         log.error("exception: {}", ex.getClass());
         return new ErrorResponse("AlreadyAssignedCallException", ex.getMessage());
     }
+
+    @MessageExceptionHandler(InvalidRouteException.class)
+    @SendToUser("/queue/errors") // /user/queue/errors
+    public ErrorResponse handleInvalidRouteException(InvalidRouteException ex) {
+        log.error("exception: {}", ex.getClass());
+        return new ErrorResponse("InvalidRouteException", ex.getMessage());
+    }
+
+    @MessageExceptionHandler(RestClientException.class)
+    @SendToUser("/queue/errors") // /user/queue/errors
+    public ErrorResponse handleRestClientException(RestClientException ex) {
+        log.error("exception: {}", ex.getClass());
+        return new ErrorResponse("RestClientException", ex.getMessage());
+    }
+
 
 }

--- a/src/main/java/goorm/humandelivery/global/config/BaseConfig.java
+++ b/src/main/java/goorm/humandelivery/global/config/BaseConfig.java
@@ -1,10 +1,16 @@
 package goorm.humandelivery.global.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 @EnableJpaAuditing
 public class BaseConfig {
 
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 }

--- a/src/main/java/goorm/humandelivery/global/exception/InvalidRouteException.java
+++ b/src/main/java/goorm/humandelivery/global/exception/InvalidRouteException.java
@@ -1,0 +1,18 @@
+package goorm.humandelivery.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class InvalidRouteException extends RuntimeException {
+    private final int resultCode;
+
+    public InvalidRouteException(int resultCode, String message) {
+        super(message);
+        this.resultCode = resultCode;
+    }
+
+    public InvalidRouteException(int resultCode, String message, Throwable cause) {
+        super(message, cause);
+        this.resultCode = resultCode;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,3 +95,8 @@ server:
     threads:
       max: 300
       min-spare: 50
+
+kakao:
+  rest:
+    api:
+      key: ${KAKAO_REST_API_KEY}

--- a/src/test/java/goorm/humandelivery/fare/application/EstimateFareServiceTest.java
+++ b/src/test/java/goorm/humandelivery/fare/application/EstimateFareServiceTest.java
@@ -1,0 +1,142 @@
+package goorm.humandelivery.fare.application;
+
+import goorm.humandelivery.driver.domain.TaxiType;
+import goorm.humandelivery.fare.application.port.out.LoadTravelInfoPort;
+import goorm.humandelivery.fare.domain.TravelInfo;
+import goorm.humandelivery.fare.dto.request.EstimateFareRequest;
+import goorm.humandelivery.fare.dto.response.EstimateFareResponse;
+import goorm.humandelivery.shared.location.domain.Location;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@SpringBootTest
+class EstimateFareServiceTest {
+
+    @Autowired
+    EstimateFareService estimateFareService;
+
+    @MockitoBean
+    LoadTravelInfoPort loadTravelInfoPort;
+
+    @Test
+    @DisplayName("주간에 출발지와 목적지를 통해 예상 요금을 확인할 수 있다.")
+    void estimateFare() {
+        Location origin = new Location(37.5665, 126.9780);
+        Location destination = new Location(37.4979, 127.0276);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(15, 0));
+        TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
+        given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
+
+        EstimateFareResponse response = estimateFareService.estimateFare(request);
+
+        assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(9600));
+        assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(13600));
+        assertThat(response.getEstimatedFares().get(TaxiType.VENTI)).isEqualTo(BigDecimal.valueOf(13600));
+        assertThat(response.getKakaoEstimatedFare()).isEqualTo(BigDecimal.valueOf(10200));
+    }
+
+    @Test
+    @DisplayName("21:59:59의 예상 요금은 심야요금을 미적용한 요금이다.")
+    void estimateFareWithBeforeNightStart() {
+        Location origin = new Location(37.5665, 126.9780);
+        Location destination = new Location(37.4979, 127.0276);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(21, 59, 59));
+        TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
+        given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
+
+        EstimateFareResponse response = estimateFareService.estimateFare(request);
+
+        assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(9600));
+        assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(13600));
+        assertThat(response.getEstimatedFares().get(TaxiType.VENTI)).isEqualTo(BigDecimal.valueOf(13600));
+    }
+
+    @Test
+    @DisplayName("22:00:00의 예상 요금은 심야요금을 적용한 요금이다.")
+    void estimateFareWithAfterNightStart() {
+        Location origin = new Location(37.5665, 126.9780);
+        Location destination = new Location(37.4979, 127.0276);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(22, 0));
+        TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
+        given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
+
+        EstimateFareResponse response = estimateFareService.estimateFare(request);
+
+        assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(11560));
+        assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(16320));
+        assertThat(response.getEstimatedFares().get(TaxiType.VENTI)).isEqualTo(BigDecimal.valueOf(16320));
+    }
+
+    @Test
+    @DisplayName("23:00:00의 예상 요금은 심야피크요금을 적용한 요금이다.")
+    void estimateFareAtDeepNightStart() {
+        Location origin = new Location(37.5665, 126.9780);
+        Location destination = new Location(37.4979, 127.0276);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(23, 0));
+        TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
+        given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
+
+        EstimateFareResponse response = estimateFareService.estimateFare(request);
+
+        assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(13420));
+        assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(16320));
+        assertThat(response.getEstimatedFares().get(TaxiType.VENTI)).isEqualTo(BigDecimal.valueOf(16320));
+    }
+
+    @Test
+    @DisplayName("01:59:59의 예상 요금은 심야피크요금을 적용한 요금이다.")
+    void estimateFareNearDeepNightEnd() {
+        Location origin = new Location(37.5665, 126.9780);
+        Location destination = new Location(37.4979, 127.0276);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(1, 59, 59));
+        TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
+        given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
+
+        EstimateFareResponse response = estimateFareService.estimateFare(request);
+
+        assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(13420));
+        assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(16320));
+        assertThat(response.getEstimatedFares().get(TaxiType.VENTI)).isEqualTo(BigDecimal.valueOf(16320));
+    }
+
+    @Test
+    @DisplayName("03:59:59의 예상 요금은 심야요금을 적용한 요금이다.")
+    void estimateFareWithBeforeNightEnd() {
+        Location origin = new Location(37.5665, 126.9780);
+        Location destination = new Location(37.4979, 127.0276);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(3, 59, 59));
+        TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
+        given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
+
+        EstimateFareResponse response = estimateFareService.estimateFare(request);
+
+        assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(11560));
+        assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(16320));
+        assertThat(response.getEstimatedFares().get(TaxiType.VENTI)).isEqualTo(BigDecimal.valueOf(16320));
+    }
+
+    @Test
+    @DisplayName("04:00:00의 예상 요금은 심야요금을 미적용한 요금이다.")
+    void estimateFareWithAfterNightEnd() {
+        Location origin = new Location(37.5665, 126.9780);
+        Location destination = new Location(37.4979, 127.0276);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(4, 0));
+        TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
+        given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
+
+        EstimateFareResponse response = estimateFareService.estimateFare(request);
+
+        assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(9600));
+        assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(13600));
+        assertThat(response.getEstimatedFares().get(TaxiType.VENTI)).isEqualTo(BigDecimal.valueOf(13600));
+    }
+}

--- a/src/test/java/goorm/humandelivery/fare/infrastructure/kakao/KakaoTravelInfoAdapterTest.java
+++ b/src/test/java/goorm/humandelivery/fare/infrastructure/kakao/KakaoTravelInfoAdapterTest.java
@@ -1,0 +1,51 @@
+package goorm.humandelivery.fare.infrastructure.kakao;
+
+import goorm.humandelivery.fare.domain.TravelInfo;
+import goorm.humandelivery.global.exception.InvalidRouteException;
+import goorm.humandelivery.shared.location.domain.Location;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class KakaoTravelInfoAdapterTest {
+
+    @Autowired
+    KakaoTravelInfoAdapter kakaoTravelInfoAdapter;
+
+    @Test
+    @DisplayName("출발지와 목적지로 예상 거리, 예상 소요 시간, 예상 카카오 요금을 확인할 수 있다.")
+    void loadTravelInfo() throws Exception {
+        // Given
+        Location origin = new Location(37.5665, 126.9780); // 서울시청
+        Location destination = new Location(37.4979, 127.0276); // 강남역
+
+        // When
+        TravelInfo travelInfo = kakaoTravelInfoAdapter.loadTravelInfo(origin, destination);
+
+        // Then
+        assertThat(travelInfo.getDistanceMeters()).isGreaterThan(1000);
+        assertThat(travelInfo.getEstimatedFareByKakao()).isGreaterThan(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("출발지와 도착지가 5m 이내로 설정된 경우 예외가 발생한다.")
+    void loadTravelInfoWithCode104() throws Exception {
+        // Given
+        Location origin = new Location(37.5665, 126.9780); // 서울시청
+        Location destination = new Location(37.5665, 126.9780); // 서울시청
+
+        // When
+        // Then
+        assertThatThrownBy(() -> kakaoTravelInfoAdapter.loadTravelInfo(origin, destination))
+                .isInstanceOf(InvalidRouteException.class)
+                .hasMessage("카카오 경로 탐색 실패 (msg: 출발지와 도착지가 5 m 이내로 설정된 경우 경로를 탐색할 수 없음)");
+
+    }
+}

--- a/src/test/java/goorm/humandelivery/fare/infrastructure/kakao/KakaoTravelInfoAdapterUnitTest.java
+++ b/src/test/java/goorm/humandelivery/fare/infrastructure/kakao/KakaoTravelInfoAdapterUnitTest.java
@@ -1,0 +1,43 @@
+package goorm.humandelivery.fare.infrastructure.kakao;
+
+import goorm.humandelivery.fare.infrastructure.kakao.dto.KakaoDirectionResponse;
+import goorm.humandelivery.shared.location.domain.Location;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoTravelInfoAdapterUnitTest {
+
+    @Mock
+    RestTemplate restTemplate;
+
+    @InjectMocks
+    KakaoTravelInfoAdapter kakaoTravelInfoAdapter;
+
+    @Test
+    @DisplayName("카카오 API 호출 시 예외가 발생한다.")
+    void loadTravelInfoWithRestClientException() throws Exception {
+        // Given
+        Location origin = new Location(37.5665, 126.9780); // 서울시청
+        Location destination = new Location(37.4979, 127.0276); // 강남역
+        given(restTemplate.exchange(any(), eq(HttpMethod.GET), any(), eq(KakaoDirectionResponse.class))).willThrow(new RestClientException("카카오 API 호출 실패"));
+
+        // When
+        // Then
+        assertThatThrownBy(() -> kakaoTravelInfoAdapter.loadTravelInfo(origin, destination))
+                .isInstanceOf(RestClientException.class)
+                .hasMessage("카카오 API 호출 실패");
+    }
+}


### PR DESCRIPTION
- 경로의 거리와 예상 요금을 위해 카카오 길찾기 API를 사용하였습니다.
- 카카오 길찾기 API 예상 요금의 경우, 차량 종류는 소형으로 고정이기 때문에 우리의 도메인과 맞지 않습니다. 따라서, 예상 요금은 비교치로 사용하기 위해 가져옵니다. 사용자에게 노출할 예상 요금은 내부의 도메인 로직을 따릅니다.
- 일반택시의 경우 중형택시로 판단하였고, 대형택시의 경우 대형승용으로 판단하여 서울시의 택시요금 체계를 따랐습니다.

<img width="715" alt="스크린샷 2025-06-02 오후 4 23 28" src="https://github.com/user-attachments/assets/ba66e98d-bae0-48ac-98cd-bd6a83e4633d" />

[참고자료]
https://news.seoul.go.kr/traffic/archives/1659
https://developers.kakaomobility.com/docs/navi-api/directions/