### PR TITLE
feat: 예상 요금 기능 컨트롤러 추가

### DIFF
--- a/src/main/java/goorm/humandelivery/call/dto/request/CallMessageRequest.java
+++ b/src/main/java/goorm/humandelivery/call/dto/request/CallMessageRequest.java
@@ -6,6 +6,7 @@ import goorm.humandelivery.driver.domain.TaxiType;
 import goorm.humandelivery.shared.location.domain.Location;
 import goorm.humandelivery.shared.messaging.CallMessage;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,9 +16,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CallMessageRequest {
 
-    @NotBlank(message = "출발 위치를 입력해 주세요.")
+    @NotNull(message = "출발 위치를 입력해 주세요.")
     private Location expectedOrigin;
-    @NotBlank(message = "도착 위치를 입력해 주세요.")
+    @NotNull(message = "도착 위치를 입력해 주세요.")
     private Location expectedDestination;
     @NotBlank(message = "택시 타입을 선택해 주세요.")
     private TaxiType taxiType;

--- a/src/main/java/goorm/humandelivery/fare/application/EstimateFareService.java
+++ b/src/main/java/goorm/humandelivery/fare/application/EstimateFareService.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
+import java.time.LocalTime;
 import java.util.EnumMap;
 import java.util.Map;
 
@@ -25,14 +26,14 @@ public class EstimateFareService implements EstimateFareUseCase {
     private final LoadTravelInfoPort loadTravelInfoPort;
 
     @Override
-    public EstimateFareResponse estimateFare(EstimateFareRequest request) {
+    public EstimateFareResponse estimateFare(EstimateFareRequest request, LocalTime requestTime) {
         TravelInfo travelInfo = loadTravelInfoPort.loadTravelInfo(request.getExpectedOrigin(), request.getExpectedDestination());
         double distance = travelInfo.getDistanceMeters();
         Map<TaxiType, BigDecimal> result = new EnumMap<>(TaxiType.class);
 
         for (TaxiType type : TaxiType.values()) {
             FarePolicy policy = getPolicyByType(type);
-            BigDecimal fare = policy.estimateFare(distance, request.getRequestTime());
+            BigDecimal fare = policy.estimateFare(distance, requestTime);
             result.put(type, fare);
             log.info("[EstimateFareService.estimateFare] 택시타입: {}, 요금: {}", type, fare);
         }

--- a/src/main/java/goorm/humandelivery/fare/application/port/in/EstimateFareUseCase.java
+++ b/src/main/java/goorm/humandelivery/fare/application/port/in/EstimateFareUseCase.java
@@ -3,8 +3,10 @@ package goorm.humandelivery.fare.application.port.in;
 import goorm.humandelivery.fare.dto.request.EstimateFareRequest;
 import goorm.humandelivery.fare.dto.response.EstimateFareResponse;
 
+import java.time.LocalTime;
+
 public interface EstimateFareUseCase {
 
-    EstimateFareResponse estimateFare(EstimateFareRequest estimateFareRequest);
+    EstimateFareResponse estimateFare(EstimateFareRequest estimateFareRequest, LocalTime requestTime);
 
 }

--- a/src/main/java/goorm/humandelivery/fare/controller/EstimateFareController.java
+++ b/src/main/java/goorm/humandelivery/fare/controller/EstimateFareController.java
@@ -1,0 +1,30 @@
+package goorm.humandelivery.fare.controller;
+
+import goorm.humandelivery.fare.application.port.in.EstimateFareUseCase;
+import goorm.humandelivery.fare.dto.request.EstimateFareRequest;
+import goorm.humandelivery.fare.dto.response.EstimateFareResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalTime;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/estimate")
+@RequiredArgsConstructor
+public class EstimateFareController {
+
+    private final EstimateFareUseCase estimateFareUseCase;
+
+    @PostMapping
+    public ResponseEntity<EstimateFareResponse> estimateFare(@RequestBody @Valid EstimateFareRequest estimateFareRequest) {
+        log.info("[EstimateFareController.estimateFare] 예상 요금 확인 호출");
+        return ResponseEntity.ok(estimateFareUseCase.estimateFare(estimateFareRequest, LocalTime.now()));
+    }
+}

--- a/src/main/java/goorm/humandelivery/fare/dto/request/EstimateFareRequest.java
+++ b/src/main/java/goorm/humandelivery/fare/dto/request/EstimateFareRequest.java
@@ -1,19 +1,22 @@
 package goorm.humandelivery.fare.dto.request;
 
 import goorm.humandelivery.shared.location.domain.Location;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalTime;
+import lombok.Setter;
 
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class EstimateFareRequest {
 
+    @NotNull(message = "출발 위치를 입력해 주세요.")
     private Location expectedOrigin;
+
+    @NotNull(message = "도착 위치를 입력해 주세요.")
     private Location expectedDestination;
-    private LocalTime requestTime;
 
 }

--- a/src/main/java/goorm/humandelivery/global/config/SecurityConfig.java
+++ b/src/main/java/goorm/humandelivery/global/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                                 "/api/v1/taxi-driver/token-info",
                                 "/api/v1/customer",
                                 "/api/v1/customer/auth-tokens",
+                                "/api/v1/estimate",
                                 "/ws/**",
                                 "/topic/**",           // 🔥 추가: 브로커 구독 경로
                                 "/app/**",

--- a/src/test/java/goorm/humandelivery/fare/application/EstimateFareServiceTest.java
+++ b/src/test/java/goorm/humandelivery/fare/application/EstimateFareServiceTest.java
@@ -32,11 +32,12 @@ class EstimateFareServiceTest {
     void estimateFare() {
         Location origin = new Location(37.5665, 126.9780);
         Location destination = new Location(37.4979, 127.0276);
-        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(15, 0));
+        LocalTime requestTime = LocalTime.of(15, 0);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination);
         TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
         given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
 
-        EstimateFareResponse response = estimateFareService.estimateFare(request);
+        EstimateFareResponse response = estimateFareService.estimateFare(request, requestTime);
 
         assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(9600));
         assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(13600));
@@ -49,11 +50,12 @@ class EstimateFareServiceTest {
     void estimateFareWithBeforeNightStart() {
         Location origin = new Location(37.5665, 126.9780);
         Location destination = new Location(37.4979, 127.0276);
-        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(21, 59, 59));
+        LocalTime requestTime = LocalTime.of(21, 59, 59);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination);
         TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
         given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
 
-        EstimateFareResponse response = estimateFareService.estimateFare(request);
+        EstimateFareResponse response = estimateFareService.estimateFare(request, requestTime);
 
         assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(9600));
         assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(13600));
@@ -65,11 +67,12 @@ class EstimateFareServiceTest {
     void estimateFareWithAfterNightStart() {
         Location origin = new Location(37.5665, 126.9780);
         Location destination = new Location(37.4979, 127.0276);
-        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(22, 0));
+        LocalTime requestTime = LocalTime.of(22, 0);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination);
         TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
         given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
 
-        EstimateFareResponse response = estimateFareService.estimateFare(request);
+        EstimateFareResponse response = estimateFareService.estimateFare(request, requestTime);
 
         assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(11560));
         assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(16320));
@@ -81,11 +84,12 @@ class EstimateFareServiceTest {
     void estimateFareAtDeepNightStart() {
         Location origin = new Location(37.5665, 126.9780);
         Location destination = new Location(37.4979, 127.0276);
-        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(23, 0));
+        LocalTime requestTime = LocalTime.of(23, 0);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination);
         TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
         given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
 
-        EstimateFareResponse response = estimateFareService.estimateFare(request);
+        EstimateFareResponse response = estimateFareService.estimateFare(request, requestTime);
 
         assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(13420));
         assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(16320));
@@ -97,11 +101,12 @@ class EstimateFareServiceTest {
     void estimateFareNearDeepNightEnd() {
         Location origin = new Location(37.5665, 126.9780);
         Location destination = new Location(37.4979, 127.0276);
-        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(1, 59, 59));
+        LocalTime requestTime = LocalTime.of(1, 59, 59);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination);
         TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
         given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
 
-        EstimateFareResponse response = estimateFareService.estimateFare(request);
+        EstimateFareResponse response = estimateFareService.estimateFare(request, requestTime);
 
         assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(13420));
         assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(16320));
@@ -113,11 +118,12 @@ class EstimateFareServiceTest {
     void estimateFareWithBeforeNightEnd() {
         Location origin = new Location(37.5665, 126.9780);
         Location destination = new Location(37.4979, 127.0276);
-        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(3, 59, 59));
+        LocalTime requestTime = LocalTime.of(3, 59, 59);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination);
         TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
         given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
 
-        EstimateFareResponse response = estimateFareService.estimateFare(request);
+        EstimateFareResponse response = estimateFareService.estimateFare(request, requestTime);
 
         assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(11560));
         assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(16320));
@@ -129,11 +135,12 @@ class EstimateFareServiceTest {
     void estimateFareWithAfterNightEnd() {
         Location origin = new Location(37.5665, 126.9780);
         Location destination = new Location(37.4979, 127.0276);
-        EstimateFareRequest request = new EstimateFareRequest(origin, destination, LocalTime.of(4, 0));
+        LocalTime requestTime = LocalTime.of(4, 0);
+        EstimateFareRequest request = new EstimateFareRequest(origin, destination);
         TravelInfo travelInfo = new TravelInfo(8000, 1200, BigDecimal.valueOf(10200));
         given(loadTravelInfoPort.loadTravelInfo(origin, destination)).willReturn(travelInfo);
 
-        EstimateFareResponse response = estimateFareService.estimateFare(request);
+        EstimateFareResponse response = estimateFareService.estimateFare(request, requestTime);
 
         assertThat(response.getEstimatedFares().get(TaxiType.NORMAL)).isEqualTo(BigDecimal.valueOf(9600));
         assertThat(response.getEstimatedFares().get(TaxiType.PREMIUM)).isEqualTo(BigDecimal.valueOf(13600));


### PR DESCRIPTION
- HTTP 요청을 통해 출발지와 목적지 사이의 예상 요금을 조회할 수 있습니다.
- NotBlank는 문자열에만 적용할 수 있어 NotNull로 수정하였습니다.
- 요청 시각은 컨트롤러단에서 LocalTime.now()를 통해 주입받도록 변경하였습니다.